### PR TITLE
Add instructions for secrets in Streamlit

### DIFF
--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,7 @@
+# Example secrets.toml
+# Rename this file to secrets.toml and fill in your credentials
+DATABASE_URL = "sqlite:///./habits.db"
+GOOGLE_CLIENT_ID = "your-google-client-id"
+GOOGLE_CLIENT_SECRET = "your-google-client-secret"
+STRAVA_CLIENT_ID = "your-strava-client-id"
+STRAVA_CLIENT_SECRET = "your-strava-client-secret"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ mkdir uploads
 
 4. Click **Deploy** → share the generated URL with friends!
 
+## 🔑 Secrets & Environment Variables
+Use a `.streamlit/secrets.toml` file to store credentials like database URLs or API keys. For example:
+
+```toml
+DATABASE_URL = "sqlite:///./habits.db"
+GOOGLE_CLIENT_ID = "your-google-client-id"
+GOOGLE_CLIENT_SECRET = "your-google-client-secret"
+STRAVA_CLIENT_ID = "your-strava-client-id"
+STRAVA_CLIENT_SECRET = "your-strava-client-secret"
+```
+
+When deployed on Streamlit Community Cloud, values from `secrets.toml` are loaded into environment variables and accessible via `os.getenv`.
+See `.streamlit/secrets.toml.example` for a template.
+
+
 ---
 
 ## 👥 Inviting Friends


### PR DESCRIPTION
## Summary
- document how to use secrets for Streamlit deployments
- provide a sample `.streamlit/secrets.toml` file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68608a5ac5b8832c8a7cbb2bbb3bbc07