### PR TITLE
Add Replit launch instructions

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,8 +1,8 @@
-run = "python cli.py"
+run = "streamlit run main.py"
 modules = ["python-3.12", "bash"]
 
 [deployment]
-run = ["python", "cli.py"]
+run = ["streamlit", "run", "main.py"]
 
 [nix]
 channel = "stable-24_05"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ mkdir uploads
    python cli.py
    ```
 
+## 🚀 Running on Replit
+
+1. Open this repository in [Replit](https://replit.com/).
+2. The `.replit` file launches the Streamlit interface:
+   ```bash
+   streamlit run main.py
+   ```
+3. Install dependencies from `requirements.txt` if prompted.
+4. The interface will be served at the Replit preview URL and uses Replit DB for storage.
+
 ---
 
 ## 👥 Inviting Friends


### PR DESCRIPTION
## Summary
- point Replit run command to Streamlit interface
- document Replit setup in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68609a0784e8832ca0ef6766a071ea67