### PR TITLE
Fix auto-import crash when optional modules missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ mkdir uploads
 
 ---
 
+## ❓ Troubleshooting
+
+If you see `ModuleNotFoundError: No module named 'sqlalchemy'` when the app starts,
+make sure the required packages are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+The app dynamically imports all `.py` files on startup. Missing packages will be
+skipped, but installing everything from `requirements.txt` avoids warnings.
+
+---
+
 ## 👥 Inviting Friends
 
 1. Share your progress with friends.

--- a/main.py
+++ b/main.py
@@ -14,7 +14,10 @@ for py_file in BASE_DIR.rglob("*.py"):
         spec = importlib.util.spec_from_file_location(module_name, py_file)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except ModuleNotFoundError as e:
+            print(f"Skipping module {module_name} due to missing dependency: {e}")
 
 # Load any assets placed in a `data/` folder so data files work on Replit or
 # locally.


### PR DESCRIPTION
## Summary
- skip auto-imported modules that fail because of missing dependencies
- document how to install requirements when `sqlalchemy` isn't found

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860a5d32abc832cabb814c22e69d074