### PR TITLE
Fix streamlit watcher on non-kqueue OS

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@
 from pathlib import Path
 import importlib.util
 import sys
+import os
 import config
+
+# Disable Streamlit file watching on platforms lacking kqueue support
+os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "none")
 
 # ---------------------------------------------------------------------------
 # Bootstrap the environment. This installs any missing dependencies listed in


### PR DESCRIPTION
## Summary
- disable Streamlit's kqueue-based file watcher by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860adcea410832c9e33e5150d52fa6b