### PR TITLE
Fix streamlit kqueue error

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,7 @@
-run = "streamlit run main.py --server.port 5000"
+# Disable Streamlit's kqueue-based file watcher for environments where the
+# kqueue APIs are unavailable (e.g. Linux). This prevents crashes when
+# running `streamlit run main.py`.
+run = "env STREAMLIT_SERVER_FILE_WATCHER_TYPE=none streamlit run main.py --server.port 5000"
 modules = ["python-3.11"]
 
 [nix]

--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@
 from pathlib import Path
 import importlib.util
 import sys
+import os
 import config
+
+# Disable Streamlit file watching on platforms lacking kqueue support
+os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "none")
 
 # ---------------------------------------------------------------------------
 # Bootstrap the environment. This installs any missing dependencies listed in


### PR DESCRIPTION
## Summary
- disable kqueue-based file watcher in `.replit` so the app runs on Linux
- keep environment override in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860adcea410832c9e33e5150d52fa6b