### PR TITLE
Fix streamlit kqueue error

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,7 @@
-run = "streamlit run main.py --server.port 5000"
+# Disable Streamlit's kqueue-based file watcher for environments where the
+# kqueue APIs are unavailable (e.g. Linux). This prevents crashes when
+# running `streamlit run main.py`.
+run = "env STREAMLIT_SERVER_FILE_WATCHER_TYPE=none streamlit run main.py --server.port 5000"
 modules = ["python-3.11"]
 
 [nix]

--- a/main.py
+++ b/main.py
@@ -4,7 +4,11 @@
 from pathlib import Path
 import importlib.util
 import sys
+import os
 import config
+
+# Disable Streamlit file watching on platforms lacking kqueue support
+os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "none")
 
 # ---------------------------------------------------------------------------
 # Bootstrap the environment. This installs any missing dependencies listed in
@@ -24,16 +28,19 @@ else:
 # Dynamically import all modules under the project so helper files can be placed
 # anywhere without manual imports.
 BASE_DIR = Path(__file__).parent
+# Skip Streamlit entrypoints so importing them doesn't trigger optional
+# kqueue-based watchers on platforms lacking those APIs.
+EXCLUDE = {"main.py", "bootstrap.py", "app.py", "habits_tracker_web.py", "__init__.py"}
 for py_file in BASE_DIR.rglob("*.py"):
-    if py_file.name not in ("main.py", "bootstrap.py", "app.py", "__init__.py"):
+    if py_file.name not in EXCLUDE:
         module_name = ".".join(py_file.relative_to(BASE_DIR).with_suffix("").parts)
         spec = importlib.util.spec_from_file_location(module_name, py_file)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         try:
             spec.loader.exec_module(module)
-        except (ModuleNotFoundError, ImportError) as e:
-            print(f"Skipping module {module_name} due to missing dependency: {e}")
+        except (ModuleNotFoundError, ImportError, AttributeError) as e:
+            print(f"Skipping module {module_name} due to import error: {e}")
 
 # Load any assets placed in a `data/` folder so data files work on Replit or
 # locally.


### PR DESCRIPTION
## Summary
- disable kqueue-based file watcher in `.replit` so the app runs on Linux
- skip Streamlit modules in bootstrap to avoid importing watcher's kqueue backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860adcea410832c9e33e5150d52fa6b