### PR TITLE
Add robust pie chart utility

### DIFF
--- a/charts.py
+++ b/charts.py
@@ -2,6 +2,10 @@
 import altair as alt
 import pandas as pd
 from datetime import datetime
+from pathlib import Path
+from typing import Union
+from PIL import Image, UnidentifiedImageError
+import matplotlib.pyplot as plt
 
 
 def plot_12week_line(logs_df: pd.DataFrame, goals: dict):
@@ -33,3 +37,40 @@ def plot_calendar_heatmap(logs_df: pd.DataFrame):
         tooltip=['week','weekday','count']
     ).properties(width=300, height=300, title='Activity Heatmap')
     return chart
+
+def create_pie_chart(images_path: Union[str, Path], results_path: Union[str, Path]) -> Path:
+    """Create a pie chart of image counts per subfolder.
+
+    Any files that cannot be opened as images are skipped rather than raising an
+    exception. The resulting chart is saved to ``results_path``.
+    """
+    images_dir = Path(images_path)
+    output_path = Path(results_path)
+
+    counts = {}
+    for img_file in images_dir.rglob("*"):
+        if img_file.is_dir():
+            continue
+        try:
+            with Image.open(img_file):
+                pass
+        except (UnidentifiedImageError, OSError):
+            # Skip unreadable files
+            print(f"Skipping unreadable image: {img_file}")
+            continue
+        label = img_file.parent.name
+        counts[label] = counts.get(label, 0) + 1
+
+    if not counts:
+        raise ValueError("No valid images found in provided directory")
+
+    labels = list(counts.keys())
+    values = [counts[l] for l in labels]
+
+    plt.figure(figsize=(6, 6))
+    plt.pie(values, labels=labels, autopct="%1.1f%%", startangle=90)
+    plt.axis("equal")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path)
+    plt.close()
+    return output_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas
 requests
 sqlalchemy
 streamlit
+matplotlib
+pillow


### PR DESCRIPTION
## Summary
- add `create_pie_chart` helper that skips unreadable images
- update dependencies for new chart function

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python bootstrap.py` *(fails: Could not install requirements due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686126eb527c832c866511100d04bc39