### PR TITLE
Fix bootstrap missing bcrypt check

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -28,6 +28,7 @@ def ensure_dependencies():
         import pandas  # noqa: F401
         import requests  # noqa: F401
         import streamlit  # noqa: F401
+        import bcrypt  # noqa: F401
     except ModuleNotFoundError:
         print("Missing dependencies detected. Installing from requirements.txt...")
         _install_requirements()


### PR DESCRIPTION
## Summary
- ensure `bcrypt` is installed on startup

## Testing
- `python -m py_compile bootstrap.py main.py app.py api.py cli.py db_utils.py config.py db.py charts.py habits_tracker_web.py`

------
https://chatgpt.com/codex/tasks/task_e_68617bd07b00832c8e7a93ee11501727