### PR TITLE
Fix bootstrap missing bcrypt check

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,9 +24,10 @@ def _install_requirements():
 def ensure_dependencies():
     """Ensure critical third-party packages are available."""
     try:
-        import sqlalchemy  # noqa: F401
+        import bcrypt  # noqa: F401
         import pandas  # noqa: F401
         import requests  # noqa: F401
+        import sqlalchemy  # noqa: F401
         import streamlit  # noqa: F401
     except ModuleNotFoundError:
         print("Missing dependencies detected. Installing from requirements.txt...")


### PR DESCRIPTION
## Summary
- ensure `bcrypt` is installed on startup
- keep dependency checks in alphabetical order

## Testing
- `python -m py_compile bootstrap.py main.py app.py api.py cli.py db_utils.py config.py db.py charts.py habits_tracker_web.py`


------
https://chatgpt.com/codex/tasks/task_e_68617bd07b00832c8e7a93ee11501727