### PR TITLE
Use hashlib for password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ pip install -r requirements.txt
 The app dynamically imports all `.py` files on startup. Missing packages will be
 skipped, but installing everything from `requirements.txt` avoids warnings.
 
-If `bcrypt` cannot be installed, the app automatically falls back to
-`hashlib.sha256` for password hashing. Existing bcrypt hashes continue to work,
-so you can run the project even without the optional dependency.
+Passwords are hashed using `hashlib.sha256` so the tracker runs anywhere
+without requiring binary dependencies.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -14,11 +14,7 @@ from config import (
 )
 import config
 from db import init_db, SessionLocal, get_user_by_email, create_user, add_log, get_followed_user_ids, User, Log, Follow
-try:
-    import bcrypt
-except ModuleNotFoundError:
-    bcrypt = None
-import hashlib
+from utils.auth import hash_password, verify_password
 from charts import plot_12week_line, plot_calendar_heatmap
 import api
 
@@ -95,10 +91,6 @@ def user_exists(email):
     return get_user_by_email(db, email) is not None
 
 
-def hash_password(pw):
-    if bcrypt:
-        return bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode()
-    return hashlib.sha256(pw.encode()).hexdigest()
 
 st.set_page_config(page_title=PAGE_TITLE, page_icon=PAGE_ICON, layout='wide')
 
@@ -161,10 +153,7 @@ if "email" not in st.session_state:
                     st.error("Invalid email or password")
                 else:
                     stored = user.hashed_password
-                    if bcrypt and stored.startswith("$2"):
-                        valid = bcrypt.checkpw(password.encode(), stored.encode())
-                    else:
-                        valid = hashlib.sha256(password.encode()).hexdigest() == stored
+                    valid = verify_password(password, stored)
                     if not valid:
                         st.error("Invalid email or password")
                     else:

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,12 +24,10 @@ def _install_requirements():
 def ensure_dependencies():
     """Ensure critical third-party packages are available."""
     try:
-        import bcrypt  # noqa: F401
         import pandas  # noqa: F401
         import requests  # noqa: F401
         import sqlalchemy  # noqa: F401
         import streamlit  # noqa: F401
-        import bcrypt  # noqa: F401
     except ModuleNotFoundError:
         print("Missing dependencies detected. Installing from requirements.txt...")
         _install_requirements()

--- a/main.py
+++ b/main.py
@@ -65,24 +65,13 @@ from db_utils import (
     get_service_token,
     db,
 )
-try:
-    import bcrypt
-except ModuleNotFoundError:
-    bcrypt = None
-import hashlib
+from utils.auth import hash_password, verify_password
 
 os.makedirs("uploads", exist_ok=True)
 
 
 def user_exists(email: str) -> bool:
     return get_user_profile(email) is not None
-
-
-def hash_password(pw: str) -> str:
-    """Hash a plaintext password."""
-    if bcrypt:
-        return bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode()
-    return hashlib.sha256(pw.encode()).hexdigest()
 
 
 def create_user(email: str, name: str, hashed_password: str):
@@ -97,9 +86,7 @@ def valid_credentials(email: str, password: str) -> bool:
     if not profile or "hashed_password" not in profile:
         return False
     stored = profile["hashed_password"]
-    if bcrypt and stored.startswith("$2"):
-        return bcrypt.checkpw(password.encode(), stored.encode())
-    return hashlib.sha256(password.encode()).hexdigest() == stored
+    return verify_password(password, stored)
 
 
 def show_leaderboard():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ sqlalchemy
 streamlit
 matplotlib
 pillow
-bcrypt

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,10 @@
+import hashlib
+
+def hash_password(password: str) -> str:
+    """Return a SHA-256 hash for the given password."""
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Check a plaintext password against an existing hash."""
+    return hash_password(password) == hashed


### PR DESCRIPTION
## Summary
- remove all optional `bcrypt` logic
- implement a small `utils.auth` helper with SHA‑256 functions
- use the new functions for sign-up and log-in
- drop `bcrypt` from requirements and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861827d8a68832c89fc0d12615a4a68