### PR TITLE
Update .replit configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -2,10 +2,32 @@
 # kqueue APIs are unavailable (e.g. Linux). This prevents crashes when
 # running `streamlit run main.py`.
 run = "env STREAMLIT_SERVER_FILE_WATCHER_TYPE=none streamlit run main.py --server.port 5000"
-modules = ["python-3.11"]
 
 [nix]
-packages = ["cairo", "ffmpeg-full", "freetype", "ghostscript", "glibcLocales", "gobject-introspection", "gtk3", "lcms2", "libimagequant", "libjpeg", "libtiff", "libwebp", "libxcrypt", "openjpeg", "pkg-config", "qhull", "tcl", "tk", "zlib"]
+packages = [
+  "cairo",
+  "cargo",
+  "ffmpeg-full",
+  "freetype",
+  "ghostscript",
+  "glibcLocales",
+  "gobject-introspection",
+  "gtk3",
+  "lcms2",
+  "libiconv",
+  "libimagequant",
+  "libjpeg",
+  "libtiff",
+  "libwebp",
+  "libxcrypt",
+  "openjpeg",
+  "pkg-config",
+  "qhull",
+  "rustc",
+  "tcl",
+  "tk",
+  "zlib",
+]
 
 [[ports]]
 localPort = 5000


### PR DESCRIPTION
## Summary
- refresh the Replit config to remove the custom Python module
- include additional development packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861847f2abc832c8d534ddb877d72e2